### PR TITLE
Fix unable to export a CSV if dataset contains a series with no values

### DIFF
--- a/export-csv.js
+++ b/export-csv.js
@@ -33,7 +33,7 @@
         // Loop the series and index values
         i = 0;
         each(this.series, function (series) {
-            if (series.options.includeInCSVExport !== false) {
+            if (series.options.includeInCSVExport !== false && series.points && series.points.length) {
                 names.push(series.name);
                 each(series.points, function (point) {
                     if (!rows[point.x]) {


### PR DESCRIPTION
We had a number of series being displayed on a Highcharts graph. When one or more of the series had no data points, it would break the export, even if that particular series wasn't being displayed (toggled off in the legend).